### PR TITLE
Automatically fetch GNU nano upstream

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -1,0 +1,21 @@
+name: Fetch-upstream
+on:
+  schedule:
+  - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '2'
+
+    - name: Fetch upstream (dirty hacks)
+      run: |
+        git reset --soft HEAD^
+        git pull git://git.savannah.gnu.org/nano.git
+        git -c user.email='davidhu0903ex3@gmail.com' -c user.name='davidhcefx' \
+          commit -m 'CI: automatically fetch upstream'
+        git push --force


### PR DESCRIPTION
## Description

I understand that this repo is a mirror of GNU nano, which implies that it should not diverge with the upstream. Based on that, this PR adds a functionality to **automatically fetch upstream** without diverging from master branch. It does so by first `git reset`, and then `git pull`, and finally `git push --force`. Hope this PR eases the task of keeping this repo up-to-date!

https://github.com/madnight/nano/blob/75e5758221d153ff86beb8fec2177d0852d3437b/.github/workflows/fetch.yml#L17-L21