### PR TITLE
Automatically fetch GNU nano upstream (fix PR issue)

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -10,12 +10,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: '2'
+        fetch-depth: '5'
 
     - name: Fetch upstream (dirty hacks)
       run: |
-        git reset --soft HEAD^
+        git reset --soft HEAD^^^^
         git pull git://git.savannah.gnu.org/nano.git
-        git -c user.email='davidhu0903ex3@gmail.com' -c user.name='davidhcefx' \
-          commit -m 'CI: automatically fetch upstream'
+        git -c user.email='mail@beuke.org' -c user.name='Fabian Beuke' commit \
+          -m 'Merge pull request #8 from davidhcefx/patch-2' \
+          -m 'Automatically fetch GNU nano upstream (fix PR issue)'
         git push --force
+


### PR DESCRIPTION
*This PR is for addressing the issue that the original PR (#7) would not work as expected, since PR itself [counts as an additional commit record](https://github.com/madnight/nano/pull/7#issuecomment-1071073895). Sorry for the inconveniences!*

## Description

I understand that this repo is a mirror of GNU nano, which implies that it should not diverge with the upstream. Based on that, this PR adds a functionality to **automatically fetch upstream** without diverging from master branch. It does so by first `git reset`, and then `git pull`, and finally `git push --force`. Hope this PR eases the task of keeping this repo up-to-date!

https://github.com/madnight/nano/blob/b51c62ac3ae146618e2fbb4f8e97a37d5d4b35c8/.github/workflows/fetch.yml#L17-L22
