### PR TITLE
Fix auto-fetch CI script

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -14,10 +14,14 @@ jobs:
 
     - name: Fetch upstream (dirty hacks)
       run: |
-        git reset --soft HEAD^^^^
+        mv .github .github~  # hide it from git
+        git reset --hard HEAD~3
         git pull git://git.savannah.gnu.org/nano.git
-        git -c user.email='mail@beuke.org' -c user.name='Fabian Beuke' commit \
-          -m 'Merge pull request #8 from davidhcefx/patch-2' \
-          -m 'Automatically fetch GNU nano upstream (fix PR issue)'
-        git push --force
+        mv .github~ .github
 
+    - name: Commit this script
+      run: |
+        git add .
+        git -c user.email='mail@beuke.org' -c user.name='Fabian Beuke' commit \
+          -m 'Merge pull request #9 from davidhcefx/patch-3'
+        git push --force


### PR DESCRIPTION
## Description

It seems that CI [didn't work as expected][ci]. After some investigation, I found that `HEAD^` [would only follow the original branch][SO-head]; commits in other branches would be ignored. In other words, running

```sh
$ git reset --soft HEAD^
```
would land in `36f13d1505e8f786fa79a6b741341b8e04bb14d8` instead of `b51c62ac3ae146618e2fbb4f8e97a37d5d4b35c8`:

```gitlog
commit 95795930c6033f155a9177d88e9f55e7bbc63f96 (HEAD -> patch-3, origin/master, origin/HEAD, master)
Merge: 36f13d1 b51c62a
Author: Fabian Beuke <mail@beuke.org>
Date:   Thu Mar 17 19:25:45 2022 +0100

    Merge pull request #8 from davidhcefx/patch-2

    Automatically fetch GNU nano upstream (fix PR issue)

commit b51c62ac3ae146618e2fbb4f8e97a37d5d4b35c8
Author: Fabian Beuke <mail@beuke.org>
Date:   Thu Mar 17 22:49:14 2022 +0800

    Merge pull request #8 from davidhcefx/patch-2

    Automatically fetch GNU nano upstream (fix PR issue)

commit 36f13d1505e8f786fa79a6b741341b8e04bb14d8
Merge: 02df950 75e5758
Author: Fabian Beuke <mail@beuke.org>
Date:   Thu Mar 17 14:54:08 2022 +0100

    Merge pull request #7 from davidhcefx/patch-1

    Automatically fetch GNU nano upstream
```

This caused us landing in the wrong commit state, resulting in `git pull` failed to fast-forward. In order to fix this, I changed to hard reset to guarantee fast-forward:

https://github.com/madnight/nano/blob/72b706f9f5b2e76f97e64154434c4cc26ba498e3/.github/workflows/fetch.yml#L15-L20

This version should work. To verify this you can also trigger it manually via _Actions_ -> _Fetch-upstream_ -> _Run workflow_:

![image](https://user-images.githubusercontent.com/23246033/160642450-8f0b49ca-6477-4425-a050-799edcee42be.png)



[ci]: https://github.com/madnight/nano/actions/runs/2049603026
[SO-head]: https://stackoverflow.com/questions/2221658/whats-the-difference-between-head-and-head-in-git